### PR TITLE
Serialize/Deserialize directly to/from the stream

### DIFF
--- a/Shuttle.Core.Json/JsonSerializer.cs
+++ b/Shuttle.Core.Json/JsonSerializer.cs
@@ -19,13 +19,24 @@ namespace Shuttle.Core.Json
 
         public Stream Serialize(object instance)
         {
-            return
-                new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(instance, _jsonSerializerSettings)));
+            var result = new MemoryStream();
+            using (var jsonWriter = new JsonTextWriter(new StreamWriter(result)) {CloseOutput = false})
+            {
+                var ser = Newtonsoft.Json.JsonSerializer.CreateDefault(_jsonSerializerSettings);
+                ser.Serialize(jsonWriter, instance);
+                jsonWriter.Flush();
+                result.Position = 0;
+                return result;
+            }
         }
 
         public object Deserialize(Type type, Stream stream)
         {
-            return JsonConvert.DeserializeObject(new StreamReader(stream).ReadToEnd(), type, _jsonSerializerSettings);
+            using (JsonTextReader jsonReader = new JsonTextReader(new StreamReader(stream)))
+            {
+                var ser = Newtonsoft.Json.JsonSerializer.CreateDefault(_jsonSerializerSettings);
+                return ser.Deserialize(jsonReader, type);
+            }
         }
 
         public static ISerializer Default()


### PR DESCRIPTION
However the current implementation of the JsonSerializer is very simple, it creates unnecessary strings.
JsonConvert internally uses the JsonTexttReader/Writer classes which uses streams. Your ISerializer interface is also using streams, so it is faster to skip the stream -> string -> stream conversions. 

Btw, the Serialize method is why returning the stream? Serializer methods (e.g .NET Fw XmlSerializer.Serialize is getting the stream as a parameter), so maybe a 
void Serialize(Stream stream, object instance) would be better.
